### PR TITLE
Address dv.manager 3.1.0 deprecation warnings.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dv.bookman
 Title: Bookmark manager
-Version: 0.0.3
+Version: 0.0.3-9000
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
@@ -13,7 +13,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.0
 Depends: R (>= 4.1)
 Imports: shiny (>= 1.7.1), DT (>= 0.19), fontawesome
-Suggests: dv.manager (>= 1.0.9.129), testthat, knitr, devtools
+Suggests: dv.manager (>= 3.1.0), testthat, knitr, devtools
 Remotes: boehringer-ingelheim/dv.manager
 VignetteBuilder: knitr
 URL: https://github.com/Boehringer-Ingelheim/dv.bookman, https://boehringer-ingelheim.github.io/dv.bookman

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.bookman 0.0.3-9000
+
+* [NOT USER-FACING] Address dv.manager deprecation warning messages
+
 # dv.bookman 0.0.3
 
 * Tweak Quality Control report

--- a/R/mock_bookman.R
+++ b/R/mock_bookman.R
@@ -72,6 +72,6 @@ mock_app_mm <- function() {
   dv.manager::run_app(
     data = list("DS" = dataset),
     module_list = module_list,
-    filter_data = "adsl"
+    filter_dataset_name = "adsl"
   )
 }

--- a/vignettes/manual.Rmd
+++ b/vignettes/manual.Rmd
@@ -57,7 +57,7 @@ app <- function() {
   dv.manager::run_app(
     data = list("DS" = dataset),
     module_list = module_list,
-    filter_data = "adsl"
+    filter_dataset_name = "adsl"
   )
 }
 ```


### PR DESCRIPTION
Minor stuff.

# Hotfix checklist

- [ ] Bumped minor version number on both DESCRIPTION and NEWS.md

- [ ] Build passes pipeline checks

- [ ] The new changes do not affect the API

- [ ] The new changes do not affect the documentation (including screenshots)

- [ ] The new changes do not impact the QC report

